### PR TITLE
fix: use unified diff for inline comments and increase diff limit to 80K

### DIFF
--- a/.github/workflows/pr-review-collect.yml
+++ b/.github/workflows/pr-review-collect.yml
@@ -66,9 +66,9 @@ jobs:
           gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/files \
             --paginate --jq '.[].filename' > /tmp/pr-data/pr_files.txt
 
-          # Get patches/diffs
-          gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/files \
-            --paginate --jq '.[].patch // empty' > /tmp/pr-data/pr_diff.txt
+          # Get unified diff (with file headers for inline comment mapping)
+          gh api repos/${{ github.repository }}/pulls/${PR_NUMBER} \
+            --header "Accept: application/vnd.github.diff" > /tmp/pr-data/pr_diff.txt
 
           # Fetch full file contents for code files
           mkdir -p /tmp/pr-data/full_files

--- a/.github/workflows/pr-review-run.yml
+++ b/.github/workflows/pr-review-run.yml
@@ -73,8 +73,8 @@ jobs:
           gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/files \
             --paginate --jq '.[].filename' > /tmp/pr-data/pr_files.txt
 
-          gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/files \
-            --paginate --jq '.[].patch // empty' > /tmp/pr-data/pr_diff.txt
+          gh api repos/${{ github.repository }}/pulls/${PR_NUMBER} \
+            --header "Accept: application/vnd.github.diff" > /tmp/pr-data/pr_diff.txt
 
           gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/files \
             --paginate --jq '.[] | select(.status != "removed") | .filename' | while read -r file; do

--- a/.tools/scripts/pr_review.py
+++ b/.tools/scripts/pr_review.py
@@ -333,7 +333,7 @@ def invoke_claude(
 
 ### Code Changes (diff)
 ```diff
-{diff[:30000]}
+{diff[:80000]}
 ```
 
 {full_files_context}


### PR DESCRIPTION
fix: use unified diff for inline comments and increase diff limit to 80K

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
