### PR TITLE
fix: remove subject_type field not supported by REST API

### DIFF
--- a/.tools/scripts/pr_review.py
+++ b/.tools/scripts/pr_review.py
@@ -418,7 +418,6 @@ def build_review_payload(parsed_review, pr_files, head_sha):
                     "path": path,
                     "line": int(line),
                     "side": "RIGHT",
-                    "subject_type": "line",
                     "body": f"🤖 {comment_body}",
                 })
     else:


### PR DESCRIPTION
fix: remove subject_type field not supported by REST API

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
